### PR TITLE
Fixes use on systems where the node binary isn't named "node"

### DIFF
--- a/lib/testrunner.js
+++ b/lib/testrunner.js
@@ -21,7 +21,7 @@ exports.run = function( files ) {
         };
 
     files.forEach( function( file ) {
-        var proc = spawn( "node", [ __dirname + "/cli.js", file.code, file.test ] );
+        var proc = spawn( process.execPath, [ __dirname + "/cli.js", file.code, file.test ] );
         
         proc.stderr.on( "data", function (data) {
             sys.print( data );


### PR DESCRIPTION
Ie. Debian packages node as /usr/bin/nodejs instead of 'node'. Using process.execPath makes sure the testrunner just works, regardless of what the node binary is called.
