### PR TITLE
Console hack

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -115,6 +115,9 @@ function extend( deep /*, obj, obj, ...*/ ) {
     for ( ; i < args.length; ++i ) {
         typeof args[i] === "object" && Object.keys( args[i] ).forEach(function( key ) {
             // if deep extending and both of keys are objects
+            if (key == "console") {
+              return;
+            }
             if ( deep === true && target[key] ) {
                 args.callee(deep, target[key], args[i][key]);    
             } else {


### PR DESCRIPTION
A quick hack to avoid the "Cannot set property console of #<Object> which has only a getter" error.

I'm still not sure where the console property in question is coming from (could JS Coverage be adding it?) but any test file whichiattempts to redefine console will get into similar trouble without this change.
