### PR TITLE
More options for how code and dependencies are included - better compatibility with tests written against browser QUnit

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,6 +7,34 @@ var root = __dirname + "/..",
     o = qunit.options,
     code, tests;
 
+/**
+ * Parses a code or dependency argument, returning an object defining the
+ * specified file path or module name. Any input ending in ".js" will be
+ * treated as a file path, otherwise it will be treated as a module name.
+ * The exports of the module will be exposed globally by default. To expose
+ * exports as a named variable, prefix the resource with the desired variable
+ * name followed by a colon.
+ * This allows you to more accurately recreate browser usage of QUnit, for
+ * tests which are portable between browser runtime environmemts and Node.js.
+ */
+function parseTestResource ( input ) {
+    var parts = input.split( ":" ),
+        requirePath = parts.pop(),
+        resource = {};
+
+    if ( /\.js$/.test( requirePath ) ) {
+        resource.file = requirePath;
+    } else {
+        resource.module = requirePath;
+    }
+
+    if ( parts.length === 1 ) {
+        resource.as = parts[0];
+    }
+
+    return resource;
+}
+
 var help = ''
         + '\nUsage: cli [options] value (boolean value can be used)'
         + '\n'
@@ -17,9 +45,9 @@ var help = ''
         + '\n -o, --errors-only report only errors'
         + '\n -e, --error-stack display error stack'
         + '\n -s, --summary display summary report'
-        + '\n -C, --cov create tests coverage report'
+        + '\n --cov create tests coverage report'
         + '\n -p, --paths, add paths to require.paths array'
-        + '\n -t, --coverage-tmp-dir change temp dir, which is used for jscoverage tool'
+        + '\n --tmp change temp dir, which is used for jscoverage tool'
         + '\n -h, --help show this help'
         + '\n';
 
@@ -27,15 +55,22 @@ for ( var key in args ) {
     switch( key ) {
         case "-c": 
         case "--code":
-            code = args[key];
+            code = parseTestResource(args[key]);
             break;
         case "-t": 
         case "--tests":
+            // it's assumed that tests arguments will be file paths whose
+            // contents are to be made global. This is consistent with use
+            // of QUnit in browsers.
             tests = args[key];
             break;
         case "-d": 
         case "--deps":
-            o.deps = args[key];
+            var deps = args[key];
+            if ( !Array.isArray ( deps ) ) {
+                deps = [deps];
+            }
+            o.deps = deps.map(parseTestResource);
             break;
         case "-o":
         case "--errors-only":

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,12 +5,13 @@ var undefined,
     noop = function(){},
     pause = false,
     queue = [],
+    results = [],
     test,
     module = {},
     QUnit = {
         api: {}
     };
-    
+
 exports.QUnit = QUnit;
 
 
@@ -20,7 +21,11 @@ exports.QUnit = QUnit;
 function run() {
     // all tests are done
     if ( queue.length <= 0 ) {
-        QUnit.done();
+        var doneResult = QUnit.done();
+        if ( doneResult ) {
+            results.push( doneResult );
+        }
+        util.print( JSON.stringify(results) );
         return;
     }
 
@@ -31,18 +36,18 @@ function run() {
         module.env.setup();
         test.setupDone = true;
     }
-            
+
     // run the test
     if ( !pause ) {
         test.fn.call( QUnit.current_testEnvironment = extend( true, test.env || {}, module.env ) );
     }
-    
+
     if ( test.async ) {
         QUnit.api.stop();
     } else if ( !pause ) {
         testDone();
     }
-    
+
     if ( !pause ) {
         run();
     }
@@ -52,16 +57,16 @@ function run() {
  * Do teardown and count expected assertions after each test is done
  */
 function testDone() {
-    
+
     if ( !test || !module ) {
         return;
     }
-  
+
     if ( module.env && module.env.teardown && !test.teardownDone ) {
         module.env.teardown();
         test.teardownDone = true;
-    } 
-    
+    }
+
     if ( pause ) {
         return;
     }
@@ -73,35 +78,35 @@ function testDone() {
         try {
             throw new Error( "Assertions amount" );
         } catch( err ) {
-            errorStack = err.stack;    
+            errorStack = err.stack;
         }
-        
+
         log({
             message: "Expected " + test.expected + " assertions, but " + test.done + " were run",
-            errorStack: errorStack  
+            errorStack: errorStack
         });
-    }  
-    
-    queue.shift();  
+    }
+
+    queue.shift();
 }
 
 /**
- * Print stringified object to stdout
+ * Adds a result object to the list of reults for later use.
  * @param {Object} obj
  */
 function log( obj ) {
-    
+
     obj.message = obj.message || "";
     obj.name = test.name || "";
     obj.module = module.name || "";
 
-    util.print( JSON.stringify(obj) + "\n" );
+    results.push(obj);
 }
 
 /**
  * Ecma 5 doesn't defines this method, so just hope they also like jQuery's way :)
  * You can pass so much objects as you like, all properties will be copied to the first object
- * 
+ *
  * @param {Object|Boolean} deep
  * @param {Object}
  * @return {Object}
@@ -111,22 +116,22 @@ function extend( deep /*, obj, obj, ...*/ ) {
     var args = arguments,
         i = typeof deep === 'boolean' ? 1 : 0,
         target = args[i];
-    
+
     for ( ; i < args.length; ++i ) {
         typeof args[i] === "object" && Object.keys( args[i] ).forEach(function( key ) {
             // if deep extending and both of keys are objects
             if ( deep === true && target[key] ) {
-                args.callee(deep, target[key], args[i][key]);    
+                args.callee(deep, target[key], args[i][key]);
             } else {
                 target[key] = args[i][key];
             }
-        });        
-    }  
-          
+        });
+    }
+
     return target;
 }
 
-exports.extend = extend;    
+exports.extend = extend;
 
 /**
  * Begin tests execution
@@ -150,14 +155,14 @@ QUnit.done = noop;
  * @param {Object} env
  */
 QUnit.api.module = function( name, env ) {
-    
+
     env = env || {};
-    
+
     module = {
         name: name,
         env: env
     };
-    
+
     return this;
 };
 
@@ -173,22 +178,22 @@ QUnit.api.test = function( name, expect, fn, async ) {
     if ( typeof name !== "string" ) {
         throw new Error( "Test name should be the first parameter" );
     }
-    
+
     var type = typeof expect,
         env;
     if ( type === "function" ) {
         fn = expect;
         expect = undefined;
-    // expect can extend module env    
+    // expect can extend module env
     } else if ( type === "object" ) {
         env = expect;
         expect = undefined;
     }
-    
+
     if ( typeof fn !== "function" ) {
         throw new Error( "No test function passed" );
     }
-    
+
     queue.push({
         name: name,
         module: module,
@@ -196,7 +201,7 @@ QUnit.api.test = function( name, expect, fn, async ) {
         expected: expect,
         env: env,
         done: 0,
-        async: async    
+        async: async
     });
 
     return this;
@@ -238,7 +243,7 @@ QUnit.api.stop = function() {
 QUnit.api.expect = function( amount ) {
     test.expected = amount;
     return this;
-};    
+};
 
 /**
  * A boolean assertion. Passes if the first argument is truthy.
@@ -250,38 +255,14 @@ QUnit.api.ok = function( value, message ) {
     var r = {
             message: message
         };
-    
+
     try {
         assert.ok( value );
     } catch (err) {
         r.errorStack = err.stack;
     }
-    
-    log(r); 
-    
-    return this;
-};    
 
-/**
- * A comparison assertion, uses ==.
- * @param {Object} actual
- * @param {Object} expected
- * @param {String} message
- */     
-QUnit.api.equals = QUnit.api.equal = function( actual, expected, message ) {
-    test.done++;
-    
-    var r = {
-            message: message
-        }; 
-           
-    try {
-        assert.equal( actual, expected );
-    } catch( err ) {
-        r.errorStack = err.stack;
-    }
-    
-    log( r );   
+    log(r);
 
     return this;
 };
@@ -291,21 +272,45 @@ QUnit.api.equals = QUnit.api.equal = function( actual, expected, message ) {
  * @param {Object} actual
  * @param {Object} expected
  * @param {String} message
- */     
-QUnit.api.notEqual = function( actual, expected, message ) {
+ */
+QUnit.api.equals = QUnit.api.equal = function( actual, expected, message ) {
     test.done++;
-    
+
     var r = {
             message: message
-        }; 
-           
+        };
+
+    try {
+        assert.equal( actual, expected );
+    } catch( err ) {
+        r.errorStack = err.stack;
+    }
+
+    log( r );
+
+    return this;
+};
+
+/**
+ * A comparison assertion, uses ==.
+ * @param {Object} actual
+ * @param {Object} expected
+ * @param {String} message
+ */
+QUnit.api.notEqual = function( actual, expected, message ) {
+    test.done++;
+
+    var r = {
+            message: message
+        };
+
     try {
         assert.notEqual( actual, expected );
     } catch( err ) {
         r.errorStack = err.stack;
     }
-    
-    log( r );   
+
+    log( r );
 
     return this;
 };
@@ -315,21 +320,21 @@ QUnit.api.notEqual = function( actual, expected, message ) {
  * @param {Object} actual
  * @param {Object} expected
  * @param {String} message
- */    
+ */
 QUnit.api.strictEqual = function( actual, expected, message ) {
     test.done++;
-    
+
     var r = {
             message: message
-        }; 
-           
+        };
+
     try {
         assert.strictEqual( actual, expected );
     } catch( err ) {
         r.errorStack = err.stack;
     }
-    
-    log( r );   
+
+    log( r );
 
     return this;
 };
@@ -342,18 +347,18 @@ QUnit.api.strictEqual = function( actual, expected, message ) {
  */
 QUnit.api.same = QUnit.api.deepEqual = function( actual, expected, message ) {
     test.done++;
-    
+
     var r = {
             message: message
-        }; 
-            
+        };
+
     try {
         assert.deepEqual( actual, expected );
     } catch( err ) {
         r.errorStack = err.stack;
     }
-    
-    log( r );  
+
+    log( r );
 
     return this;
 };
@@ -363,15 +368,15 @@ QUnit.api.raises = function( actual, message ) {
     var r = {
             message: message
         };
-        
+
     try {
-        assert.throws( actual, message );    
+        assert.throws( actual, message );
     } catch( err ) {
         r.errorStack = err.stack;
     }
-    
+
     log( r );
-    
+
     return this;
 };
 
@@ -389,10 +394,10 @@ QUnit.objectType = function( obj ) {
     if (obj === null) {
         return "null";
     }
-    
+
     var type = Object.prototype.toString.call( obj )
         .match(/^\[object\s(.*)\]$/)[1] || '';
-    
+
     switch (type) {
         case 'Number':
         if (isNaN(obj)) {
@@ -411,7 +416,7 @@ QUnit.objectType = function( obj ) {
     if (typeof obj === "object") {
         return "object";
     }
-    return undefined;    
+    return undefined;
 }
 
 // Test for equality any JavaScript type.
@@ -435,7 +440,7 @@ QUnit.equiv = function () {
             }
         }
     }
-    
+
     var callbacks = function () {
 
         // for string, boolean, number and null
@@ -490,12 +495,12 @@ QUnit.equiv = function () {
                 if ( ! (QUnit.objectType(b) === "array")) {
                     return false;
                 }
-                
+
                 len = a.length;
                 if (len !== b.length) { // safe and faster
                     return false;
                 }
-                
+
                 //track reference to avoid circular references
                 parents.push(a);
                 for (i = 0; i < len; i++) {
@@ -528,7 +533,7 @@ QUnit.equiv = function () {
                 callers.push(a.constructor);
                 //track reference to avoid circular references
                 parents.push(a);
-                
+
                 for (i in a) { // be strict: don't ensures hasOwnProperty and go deep
                     loop = false;
                     for(j=0;j<parents.length;j++){

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -3,18 +3,33 @@ var qunit = require( "./api" ),
     util = require( "util" ),
     options = JSON.parse( process.argv[2] );
 
+function requireTestResource(res) {
+    // test resource must define .file or .module
+    var requirePath = res.file ?
+                      res.file.replace( /\.js$/, "" ) :
+                      res.module,
+        mod = {};
+    // test resource can define .as to expose its exports as a named object
+    if (res.as) {
+        mod[res.as] = require( requirePath );
+    } else {
+        mod = require ( requirePath );
+    }
+    qunit.extend( global, mod );
+}
+
 // add paths to require
 if ( options.paths ) {
     require.paths.push.apply( require.paths, options.paths );    
 }
 
 // require deps
-options.deps.forEach(function( file ){
-    require( file.replace( /\.js$/, "" ) );
+options.deps.forEach(function( dep ){
+    requireTestResource( dep );
 });
 
 // require code
-qunit.extend( global, require( options.code.replace( /\.js$/, "" ) ) );
+requireTestResource( options.code );
 
 // require tests
 options.tests.forEach(function( test ){
@@ -23,11 +38,9 @@ options.tests.forEach(function( test ){
 
 if ( options.coverage ) {
     QUnit.done = function() {
-        util.print(
-            JSON.stringify({
+        return {
                 cov: _$jscoverage
-            }) + "\n"    
-        );
+        };
     };  
 }
 

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -79,19 +79,21 @@ function printSummary( report, cov ) {
 function run( opts, report, callback ) {
     var child, 
         testname,
-        cov;    
+        cov,
+        results = [];
 
     child = spawn( process.execPath, [__dirname + "/bootstrap.js", JSON.stringify( opts )] );
     
     child.stdout.on( "data", function ( buf ) {
-        buf.toString().split( "\n" ).forEach(function( data ) {
+        results.push(buf.toString());
+    });
             
-            if ( data.length <=0 ) {
-                return;
-            }
+    child.stderr.on( "data", function ( buf ) {
+        util.print( "stderr: " + buf );
+    });
 
-            data = JSON.parse( data );
-
+    child.on( "exit", function( code ) {
+        JSON.parse( results.join( "" ) ).forEach(function( data ) {
             report.assertions++;
             
             // its coverage json
@@ -111,13 +113,7 @@ function run( opts, report, callback ) {
 
             logTest( data );
         });
-    });
-    
-    child.stderr.on( "data", function ( buf ) {
-        util.print( "stderr: " + buf );
-    });    
 
-    child.on( "exit", function( code ) {
         report.files++;
         
         if ( typeof callback === "function" ) {
@@ -128,20 +124,22 @@ function run( opts, report, callback ) {
 
 /**
  * Make an absolute path from relative
- * @param {String} str
- * @return {String}
+ * @param {String|Object} file
+ * @return {String|Object}
  */
-function absPath( str ) {
-    if ( str.substr( 0, 1 ) !== "/" ) {
-        str = path.join( process.cwd(), str );             
+function absPath( file ) {
+    if ( typeof file === "string" && file.charAt(0) !== "/" ) {
+        file = path.join( process.cwd(), file );
+    } else if ( file.file && file.file.charAt(0) !== "/" ) {
+        file.file = path.join( process.cwd(), file.file );
     }
     
-    return str;
+    return file;
 }
 
 /**
  * Convert path or array of paths to array of abs paths
- * @param {Array|String} files
+ * @param {Array|String|Object} files
  * @return {Array}
  */
 function toArray( files ) {
@@ -151,7 +149,7 @@ function toArray( files ) {
         files.forEach( function( file ) {
             ret.push( absPath(file) );
         });
-    } else if ( typeof files === "string" ) {
+    } else if (files) {
         ret.push( absPath(files) );
     }
     
@@ -188,11 +186,6 @@ exports.run = function( files, callback ) {
             coverage: opts.coverage || options.coverage
         };
         
-        // absolutize all urls
-        opts.tests = opts.tests.map( function( str ) {
-            return absPath( str );
-        });   
-        
         function finished( cov ) {
             if ( report.files < files.length ) {
                 return;
@@ -210,8 +203,8 @@ exports.run = function( files, callback ) {
         }        
         
         if ( opts.coverage ) {
-            coverage.instrument( opts.code, function( newCodePath, cleanup ) {
-                opts.code = newCodePath;
+            coverage.instrument( opts.code.file, function( newCodePath, cleanup ) {
+                opts.code.file = newCodePath;
                 run( opts, report, function(cov) {
                     cleanup();
                     finished(cov);    


### PR DESCRIPTION
I've added more configuration options, which have successfully allowed me to reuse tests I wrote against the browser version of QUnit, only having to redefine "module" at the top of each test file, as already documented. The new options are:
- **Exposing a module as a global named object, instead of making its exports global** - I needed this option to simulate including the code under test in the browser which only exposes itself to the global scope via a namespace object.

In the CLI, this is implemented by allowing users to pass a variable name with a : suffix, like so:

```
varName:./path/to/code.js
```

To support carrying this variable name around, code and dependencies are represented by an `Object` with `.file`, `.module` and `.as` properties instead of a `String`. The `toArray` and `absPath` methods have been adjusted to deal with this.
- **Including an already-installed Node.js module as a dependency** - I needed this option to simulate including other libraries which were used in the test code itself, without having to bundle the library into my own project.
  
  This is implemented simply by checking if the given file ends with `".js"` - `".js"` indicates a file path, otherwise it's assumed to be a module name.

You can see examples of these features being used via the API in https://github.com/insin/newforms/blob/master/tests/tests.js - command line equivalents to these tests would be:

```
qunit -c time:../src/time.js -d ./customAsserts.js -t ./time.js
qunit -c forms:../newforms.js -d ./customAsserts.js DOMBuilder:DOMBuilder -t ./util.js ./validators.js ./forms.js ./formsets.js ./fields.js ./errormessages.js ./widgets.js ./extra.js ./regressions.js
```

Additionally, with a large number of tests. I was finding that when running on Ubunto, the kernel was making its own mind up about when the streams for the spawned processes which run the tests should be flushed - this was resulting in partial JSON occasionally being received in the buffer when the data event fired, resulting in an error upon attempting to `JSON.parse()` it. To get around this, test results are saved up and only sent when the tests are complete, likewise on the receiving end.  I can rework this fix into its own branch & patch if you'd prefer.
