### PR TITLE
port timeout for stop() with semaphore

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -4,6 +4,8 @@ var util = require( "util" ),
 
 var undefined,
     pause = false,
+    timeout,
+    semaphore = 0,
     queue = [],
     results = [],
     test,
@@ -187,17 +189,40 @@ QUnit.api.asyncTest = function( name, expect, fn ) {
  * Start tests execution
  */
 QUnit.api.start = function() {
-    pause = false;
-    testDone();
-    run();
+    semaphore--;
+    if(semaphore > 0) {
+        return this;
+    }
+    if(semaphore < 0) {
+        semaphore = 0;
+    }
+
+    setTimeout( function() {
+        if( timeout ) {
+            clearTimeout( timeout );
+        }
+        console.warn( "pause = false" );
+        pause = false;
+        testDone();
+        run();
+    }, 13);
     return this;
 };
 
 /**
  * Stop tests execution
  */
-QUnit.api.stop = function() {
+QUnit.api.stop = function( delay ) {
+    semaphore++;
     pause = true;
+
+    if( delay > 0 ) {
+        clearTimeout( timeout );
+        timeout = setTimeout( function() {
+            QUnit.api.ok( false, "Delayed test timed out!" );
+            QUnit.api.start();
+        }, delay );
+    }
     return this;
 };
 

--- a/test/api.js
+++ b/test/api.js
@@ -124,6 +124,19 @@ asyncTest("asyncTest", 2, function() {
 });
 } // end asyncTest tests
 
+test("sync", 2, function() {
+    stop();
+    setTimeout(function() {
+        ok(true);
+        start();
+    }, 13);
+    stop();
+    setTimeout(function() {
+        ok(true);
+        start();
+    }, 125);
+});
+
 module("save scope", {
     setup: function() {
         this.foo = "bar";


### PR DESCRIPTION
This patch comes from qunit. The delay is most probably by jeresig, the
semaphore patch is by jzaefferer:
https://github.com/jquery/qunit/commit/9dc583c766472b091466c473f1656271e06fd185
