### PR TITLE
Fork nofds passenv

### DIFF
--- a/lib/testrunner.js
+++ b/lib/testrunner.js
@@ -20,16 +20,11 @@ var options = exports.options = {
  */
 function runOne(opts, callback) {
     var child;
-
-    child = cp.fork(
-        __dirname + '/child.js', 
-        [JSON.stringify(opts)], 
-        {customFds: [0, -1, -1]}
+	child = cp.fork(
+        __dirname + '/child.js',
+        [JSON.stringify(opts)],
+		{ env: process.env }
     );
-
-    // forward stderr and stdout streams from the child    
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
 
     child.on('message', function(msg) {
         if (msg.event === 'assertionDone') {


### PR DESCRIPTION
child_process.fork() does not support customFds (custom file
descriptors), at least with Node.JS v0.5.9. Child need to communicate
through an event channel which is already implemented in node-qunit, so
this part of the patch should be safe.

The next change is passing the parent process environment to the child
upon creation. This is required when using $NODE_PATH or you the child
will not be able to find the node modules it depends upon (for example
the 'underscore' module).
