### PR TITLE
bump required node version from 0.6 to >= 0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "keywords": ["TDD", "QUnit", "unit", "testing", "tests", "async"],
     "bin": {"qunit": "./bin/cli.js"},
-    "engines": {"node": "0.6.x"},
+    "engines": {"node": ">= 0.6.x"},
     "scripts": {
         "test": "make test"
     },


### PR DESCRIPTION
I suggest to bump up required node version, so that latest module will install in more recent Node versions, rather than an old one.

thanks!
