### PR TITLE
Add the capacity to use node-inspector for child debugging

### DIFF
--- a/lib/child.js
+++ b/lib/child.js
@@ -1,6 +1,8 @@
 var path = require('path'),
     fs = require('fs'),
+    os = require('os'),
     vm = require('vm'),
+    debug = require('vm'),
     _ = require('underscore'),
     trace = require('tracejs').trace;
 
@@ -18,33 +20,58 @@ sandbox = {
     window: {setTimeout: setTimeout},
     console: console,
     clearTimeout: clearTimeout,
-    Date: Date
+    Date: Date,
+    dbgTimeout: options.debug.timeout
 };
 
-try {
-    qunitCode = fs.readFileSync(qunitPath, 'utf-8');
-} catch( err ) {
-    console.error('You are missing upstream QUnit library in deps/qunit');
-    console.error('Using, maybe you forgot to update the submodules:');
-    console.error('git submodule init && git submodule update');
-    process.exit(1);
+function waitms(msToWait) 
+{
+	var date = new Date();
+	var curDate = null;
+
+	do { 
+		curDate = new Date();	
+		debugger;
+	} 
+	while(curDate-date < msToWait);
+} 
+
+try
+{
+	if (process.platform === 'win32') {
+		console.log('Debug mode not yet supported under windows');		
+		processScript();		
+	}
+	else {
+		if (options.debug.vmbreak) {
+			options.debug.spawnbreak = true;
 }
 
+		if (options.debug.spawnbreak) {
+			process.kill(process.pid, 'SIGUSR1');
 
-vm.runInNewContext(
-    '(function(){'+ qunitCode +'}.call(window))',
-    sandbox,
-    qunitPath
-);
+			// Now it's time to set a breakpoint
+			process.nextTick(function () {
+				waitms(options.debug.timeout);				
+				processScript();
+			});					
+		}
+		else {
+			processScript();
+		}
+	}
+}
+catch(err) {
+	console.log(err);
+}
 
-// make qunit api global, like it is in the browser
-_.extend(global, sandbox.exports);
 
 /**
  * Require a resource.
  * @param {Object} res
  */
 function load(res) {
+
     var requirePath = res.path.replace(/\.js$/, '');
 
     // test resource can define'namespace'to expose its exports as a named object
@@ -60,6 +87,53 @@ function load(res) {
  */
 function calcCoverage() {
 
+}
+
+/**
+ * Provide better stack traces
+ */
+var error = console.error;
+console.error = function(obj) {
+    // log full stacktrace
+    if (obj && obj.stack) {
+        obj = trace(obj);
+    }
+
+    return error.apply(this, arguments);
+};
+
+
+function processScript()
+{
+	try {
+	    qunitCode = fs.readFileSync(qunitPath, 'utf-8');
+	} catch( err ) {
+	    console.error('You are missing upstream QUnit library in deps/qunit');
+	    console.error('Using, maybe you forgot to update the submodules:');
+	    console.error('git submodule init && git submodule update');
+	    process.exit(1);
+	}
+
+	code = (options.debug.vmbreak) ? 'function waitms(msToWait) { var date = new Date(); var curDate = null; do {  curDate = new Date(); debugger; }  while(curDate-date < msToWait); }; waitms(dbgTimeout);' : '';		
+	code += '(function(){'+ qunitCode +'}.call(window))';
+	
+	vm.runInNewContext(
+	    code,
+	    sandbox,
+	    qunitPath
+	);
+
+	// make qunit api global, like it is in the browser
+	_.extend(global, sandbox.exports);
+
+	// require deps
+	options.deps.forEach(load);
+
+	// require code
+	load(options.code);
+
+	// require tests
+	options.tests.forEach(load);
 }
 
 /**
@@ -101,10 +175,12 @@ QUnit.testDone(function(data) {
     });
 });
 
+
 /**
  * Callback for all done tests in the file.
  * @param {Object} res
  */
+ 
 QUnit.done(_.debounce(function(data) {
     if (options.coverage) {
         data.coverage = calcCoverage();
@@ -115,25 +191,3 @@ QUnit.done(_.debounce(function(data) {
         data: data
     });
 }, 1000));
-
-/**
- * Provide better stack traces
- */
-var error = console.error;
-console.error = function(obj) {
-    // log full stacktrace
-    if (obj && obj.stack) {
-        obj = trace(obj);
-    }
-
-    return error.apply(this, arguments);
-};
-
-// require deps
-options.deps.forEach(load);
-
-// require code
-load(options.code);
-
-// require tests
-options.tests.forEach(load);

--- a/lib/testrunner.js
+++ b/lib/testrunner.js
@@ -35,6 +35,18 @@ options = exports.options = {
     // run test coverage tool
     coverage: false,
 
+    // debug options
+    debug: {
+	// timeout if no debugger attached (in ms)
+	timeout: 5000,
+    
+	// break at child spawn
+	spawnbreak: true,
+	
+	// break in VM
+	vmbreak : true
+    },
+    
     // define dependencies, which are required then before code
     deps: null,
 
@@ -150,7 +162,7 @@ exports.run = function(files, callback) {
         }
 
         if (opts.coverage) {
-            converage.instrument(opts.code);
+            coverage.instrument(opts.code);
         } else {
             runOne(opts, finished);
         }


### PR DESCRIPTION
Add the capacity to use node-inspector. It permits to debug the entire chain, from the calling program to the running test via exploring QUnit at the same time. In fact with this you can track and debug inside QUnit
