### PR TITLE
Update version of colors dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
        "argsparser": "0.0.6",
        "cli-table": "0.0.2",
        "tracejs": "0.1.4",
-       "colors": "0.6.0"
+       "colors": "0.6.0-1"
     },
     "devDependencies": {
         "chainer": "0.0.5",


### PR DESCRIPTION
For issue - https://github.com/kof/node-qunit/issues/66

The version of color.js used in node-qunit is 0.6.0. This version however has an issue where if a different version of colors is used by another module in the project, throws an error.

More details - https://gist.github.com/1451296

This issue is fixed in version 0.6.0-1 Marak/colors.js@3c2eb9d

Solution - upgrade package.json to include the newer version of color dependency.
