### PR TITLE
Attach dependencies to the global scope

### DIFF
--- a/lib/child.js
+++ b/lib/child.js
@@ -124,7 +124,9 @@ console.error = function(obj) {
 };
 
 // require deps
-options.deps.forEach(_require, true);
+options.deps.forEach(function(dep) {
+    _require(dep, true);
+});
 
 // require code
 _require(options.code, true);

--- a/test/testrunner.js
+++ b/test/testrunner.js
@@ -68,6 +68,26 @@ chain.add('attach code to global', function() {
     });
 });
 
+chain.add('attach deps to global', function() {
+    tr.run({
+        deps: fixtures + '/child-code-global.js',
+        code: fixtures + '/testrunner-code.js',
+        tests: fixtures + '/child-tests-global.js',
+    }, function(err, res) {
+        var stat = {
+                files: 1,
+                tests: 1,
+                assertions: 2,
+                failed: 0,
+                passed: 2
+            };
+
+        delete res.runtime;
+        a.deepEqual(stat, res, 'attaching dependencies to global works');
+        chain.next();
+    });
+});
+
 chain.add('attach code to a namespace', function() {
     tr.run({
         code: {


### PR DESCRIPTION
Correct the use of `Array.prototype.forEach` so that test dependencies
are attached to the global scope as intended.
