### PR TITLE
Remove dependency on "colors"

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -1,7 +1,6 @@
 var fs = require('fs'),
     util = require('util'),
     _ = require('underscore'),
-    colors = require('colors'),
     bunker;
 
 try {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
        "underscore": "1.3.3",
        "argsparser": "0.0.6",
        "cli-table": "0.0.2",
-       "tracejs": "0.1.4",
-       "colors": "0.6.0"
+       "tracejs": "0.1.4"
     },
     "devDependencies": {
         "chainer": "0.0.5",


### PR DESCRIPTION
This module isn't used, so it can be safely removed.

(Context: I'm having trouble using node-qunit with [Grunt](http://gruntjs.com) because Grunt already loads Colors, and [this version of Colors throws an error when loaded more than once](https://github.com/Marak/colors.js/blob/v0.6.0/colors.js#L50), for some reason.)
