### PR TITLE
Support nodejs 0.6.0+ (including v0.10.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     },
     "keywords": ["TDD", "QUnit", "unit", "testing", "tests", "async"],
     "bin": {"qunit": "./bin/cli.js"},
-    "engines": {"node": ">=0.6.0 < 0.9.0"},
+    "engines": {"node": ">=0.6.0"},
     "scripts": {
         "test": "make test"
     },
-   "dependencies": {
+    "dependencies": {
        "underscore": "1.3.3",
        "argsparser": "0.0.6",
        "cli-table": "0.0.2",


### PR DESCRIPTION
I tested node-qunit 0.5.15 on:
- nodejs v0.10.0
- nodejs v0.8.21
- nodejs v0.6.10

Passing without errors.

This fixes the following warning on npm-install:

```
npm WARN engine qunit@0.5.15: wanted: {"node":">=0.6.0 < 0.9.0"} (current: {"node":"v0.10.0","npm":"1.2.14"})
```

---

Also fixed a missing space in the indentation of another object.
