### PR TITLE
Sort by module before logging the assertions and the tests

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -93,6 +93,8 @@ print.assertions = function() {
         head: ['Module', 'Test', 'Assertion', 'Result']
     });
 
+    data.assertions.sort(function(a,b){if(a.module > b.module) return 1; if(a.module < b.module) return -1; return 0});
+
     data.assertions.forEach(function(data) {
         // just easier to read the table
         if (data.module === currentModule) {
@@ -155,6 +157,8 @@ print.tests = function() {
     table = new Table({
         head: ['Module', 'Test', 'Failed', 'Passed', 'Total']
     });
+
+    data.tests.sort(function(a,b){if(a.module > b.module) return 1; if(a.module < b.module) return -1; return 0});
 
     data.tests.forEach(function(data) {
         // just easier to read the table


### PR DESCRIPTION
When you launch a set of tests from different files, the log prints the result with interlace modules. Sort before logging prevents this.
