### PR TITLE
Update child.js

### DIFF
--- a/lib/child.js
+++ b/lib/child.js
@@ -1,5 +1,4 @@
 var QUnit = require('qunitjs'),
-    path = require('path'),
     _ = require('underscore'),
     trace = require('tracejs').trace,
     coverage = require('./coverage'),

--- a/lib/child.js
+++ b/lib/child.js
@@ -13,7 +13,7 @@ var QUnit = require('qunitjs'),
 require('../support/json/cycle');
 
 var options = JSON.parse(process.argv.pop()),
-    currentModule = path.basename(options.code.path, '.js');
+    currentModule = "";
 
 // send ping messages to when child is blocked.
 // after I sent the first ping, testrunner will start to except the next ping


### PR DESCRIPTION
Keep module/suiteName logging consistent with QUnit behaviour in the browser. In the browser if no module is defined the default is empty string.